### PR TITLE
Set Grafana apt_key state to present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased]
+### Fixed
+- *Set Grafana GPG key state to present else the Grafana can't be found when installing* @edwinkortman
 
 ## [1.2.0] - 2018-03-29
 ## [Full Changelog](https://github.com/idealista/grafana-role/compare/1.1.0...1.2.0)

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,6 +21,7 @@
 - name: GRAFANA | Debian repo key on package cloud
   apt_key:
     url: "{{ grafana_key }}"
+    state: present
 
 - name: GRAFANA | Debian grafana repo
   apt_repository:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,5 +2,5 @@
 grafana_required_libs:
   - apt-transport-https
 
-grafana_repo: "deb https://packagecloud.io/grafana/stable/debian/ {{ ansible_distribution_release }} main"
-grafana_key: "https://packagecloud.io/gpg.key"
+grafana_repo: "deb https://packages.grafana.com/oss/deb stable main"
+grafana_key: "https://packages.grafana.com/gpg.key"


### PR DESCRIPTION
### Description of the Change
Not sure if it's a new default but not setting the `apt_key` state to present results in Grafana not being found when installing the package (because the key is not present).

### Benefits
The role will actually install Grafana and not stop executing.

### Possible Drawbacks
None.

### Applicable Issues
None.